### PR TITLE
feat: add vercel-build script to package.json for legacy peer dependency installation and Next.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --config src/testing/config/jest.config.js"
+    "test": "jest --config src/testing/config/jest.config.js",
+    "vercel-build": "npm install --legacy-peer-deps && next build"
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",


### PR DESCRIPTION
feat: add vercel-build script to package.json for legacy peer dependency installation and Next.js build